### PR TITLE
Refactor for defensiveness, and fix bug in a test case

### DIFF
--- a/src/main/java/uk/gov/justice/laa/crime/cfecrime/utils/FullMeansTestOutcomeCalculator.java
+++ b/src/main/java/uk/gov/justice/laa/crime/cfecrime/utils/FullMeansTestOutcomeCalculator.java
@@ -10,60 +10,81 @@ import java.util.Set;
 @Slf4j
 public class FullMeansTestOutcomeCalculator {
 
-    private FullMeansTestOutcomeCalculator(){
-    }
-
     public static MeansTestOutcome getFullMeansTestOutcome(FullAssessmentResult result, CaseType caseType, MagCourtOutcome magCourtOutcome){
-        log.debug("FullMeansTestOutcome start. Inputs: result = {} caseType = {} magCourtOutcome = {}", result, caseType, magCourtOutcome);
+        log.debug("FullMeansTestOutcome start. Inputs: caseType = {} magCourtOutcome = {} result = {}", caseType, magCourtOutcome, result);
 
         MeansTestOutcome meansTestOutcome = null;
 
-        // Magistrates' court
-        if (caseType == CaseType.SUMMARY_ONLY ||
-            caseType == CaseType.COMMITAL ||
-            (caseType == CaseType.EITHER_WAY && magCourtOutcome != MagCourtOutcome.COMMITTED_FOR_TRIAL && magCourtOutcome != null)) {
-                if (result == FullAssessmentResult.FAIL) {
+        if (result == null) {
+            meansTestOutcome = null;
+        } else if (isCaseBeingHeardInMagistrateCourt(caseType, magCourtOutcome)) {
+            switch (result) {
+                case FAIL:
                     meansTestOutcome = MeansTestOutcome.INELIGIBLE;
-                }
-                if (result == FullAssessmentResult.PASS) {
+                    break;
+                case PASS:
                     meansTestOutcome = MeansTestOutcome.ELIGIBLE_WITH_NO_CONTRIBUTION;
-                }
-        }
-
-        // Crown Court
-        if (caseType == CaseType.INDICTABLE ||
-            caseType == CaseType.CC_ALREADY ||
-            (caseType == CaseType.EITHER_WAY && magCourtOutcome == MagCourtOutcome.COMMITTED_FOR_TRIAL)) {
-                if (result == FullAssessmentResult.INEL) {
+                    break;
+                default:
+                    meansTestOutcome = null;
+            }
+        } else if (isCaseBeingHeardInCrownCourtExcludingAppeals(caseType, magCourtOutcome)) {
+            switch (result) {
+                case INEL:
                     meansTestOutcome = MeansTestOutcome.INELIGIBLE;
-                }
-                if (result == FullAssessmentResult.FAIL) {
+                    break;
+                case FAIL:
                     meansTestOutcome = MeansTestOutcome.ELIGIBLE_WITH_CONTRIBUTION;
-                }
-                if (result == FullAssessmentResult.PASS) {
+                    break;
+                case PASS:
                     meansTestOutcome = MeansTestOutcome.ELIGIBLE_WITH_NO_CONTRIBUTION;
-                }
-        }
-
-        // Appeal to Crown Court
-        if (caseType == CaseType.APPEAL_CC) {
-                if (result == FullAssessmentResult.FAIL) {
+                    break;
+            }
+        } else if (caseType == CaseType.APPEAL_CC) {
+            switch (result) {
+                case FAIL:
                     meansTestOutcome = MeansTestOutcome.ELIGIBLE_WITH_CONTRIBUTION;
-                }
-                if (result == FullAssessmentResult.PASS) {
+                    break;
+                case PASS:
                     meansTestOutcome = MeansTestOutcome.ELIGIBLE_WITH_NO_CONTRIBUTION;
-                }
+                    break;
+                default:
+                    meansTestOutcome = null;
+            }
         }
 
         if (meansTestOutcome == null) {
-            throw new RuntimeException("FullMeansTestOutcome: Undefined outcome for these inputs: Full Means Test result = " + result +
-                                       " caseType = " + caseType + " magCourtOutcome = " + magCourtOutcome);
+            throw new RuntimeException("FullMeansTestOutcome: Undefined outcome for these inputs: Full Means Test " +
+                                       " caseType = " + caseType + " magCourtOutcome = " + magCourtOutcome + " result = " + result);
         }
         log.info("FullMeansTestOutcome end. Outputs: meansTestOutcome = {}", meansTestOutcome);
         return meansTestOutcome;
     }
 
+    private static boolean isCaseBeingHeardInMagistrateCourt(CaseType caseType, MagCourtOutcome magCourtOutcome) {
+        return (
+            caseType == CaseType.SUMMARY_ONLY ||
+            caseType == CaseType.COMMITAL ||
+            (
+                caseType == CaseType.EITHER_WAY &&
+                magCourtOutcome != MagCourtOutcome.COMMITTED_FOR_TRIAL &&
+                magCourtOutcome != null
+            )
+        );
+    }
+
+    private static boolean isCaseBeingHeardInCrownCourtExcludingAppeals(CaseType caseType, MagCourtOutcome magCourtOutcome) {
+        return (
+            caseType == CaseType.INDICTABLE ||
+            caseType == CaseType.CC_ALREADY ||
+            (
+                caseType == CaseType.EITHER_WAY &&
+                magCourtOutcome == MagCourtOutcome.COMMITTED_FOR_TRIAL
+            )
+        );
+    }
+
+    private FullMeansTestOutcomeCalculator(){
+    }
+
 }
-
-
-

--- a/src/main/java/uk/gov/justice/laa/crime/cfecrime/utils/FullMeansTestOutcomeCalculator.java
+++ b/src/main/java/uk/gov/justice/laa/crime/cfecrime/utils/FullMeansTestOutcomeCalculator.java
@@ -14,40 +14,52 @@ public class FullMeansTestOutcomeCalculator {
     }
 
     public static MeansTestOutcome getFullMeansTestOutcome(FullAssessmentResult result, CaseType caseType, MagCourtOutcome magCourtOutcome){
-        log.debug("Get the outcome of the Full Means Test. Inputs: result = {} caseType = {} magCourtOutcome = {}", result, caseType, magCourtOutcome);
-
-        //Fail result: Heard In Magistrates Court
-        Set<CaseType> caseTypesHeardInMagistratesCourt = Set.<CaseType>of(CaseType.COMMITAL, CaseType.SUMMARY_ONLY, CaseType.EITHER_WAY);
+        log.debug("FullMeansTestOutcome start. Inputs: result = {} caseType = {} magCourtOutcome = {}", result, caseType, magCourtOutcome);
 
         MeansTestOutcome meansTestOutcome = null;
-        if (result != null && caseType != null && magCourtOutcome != null) {
 
-            if (result == FullAssessmentResult.PASS) {
-                    //All Eligible with no contribution
-                    meansTestOutcome = MeansTestOutcome.ELIGIBLE_WITH_NO_CONTRIBUTION;
-            }
-            if (result == FullAssessmentResult.FAIL) {
-                // Either way" - offence type that could be heard in Magistrates Court or
-                // Crown Court AND magistrate outcome is NOT COMMITTED_FOR_TRIAL
-                if ((caseType == CaseType.EITHER_WAY && magCourtOutcome != MagCourtOutcome.COMMITTED_FOR_TRIAL) ||
-                        caseTypesHeardInMagistratesCourt.contains(caseType)) {
+        // Magistrates' court
+        if (caseType == CaseType.SUMMARY_ONLY ||
+            caseType == CaseType.COMMITAL ||
+            (caseType == CaseType.EITHER_WAY && magCourtOutcome != MagCourtOutcome.COMMITTED_FOR_TRIAL && magCourtOutcome != null)) {
+                if (result == FullAssessmentResult.FAIL) {
                     meansTestOutcome = MeansTestOutcome.INELIGIBLE;
-                }else{
+                }
+                if (result == FullAssessmentResult.PASS) {
+                    meansTestOutcome = MeansTestOutcome.ELIGIBLE_WITH_NO_CONTRIBUTION;
+                }
+        }
+
+        // Crown Court
+        if (caseType == CaseType.INDICTABLE ||
+            caseType == CaseType.CC_ALREADY ||
+            (caseType == CaseType.EITHER_WAY && magCourtOutcome == MagCourtOutcome.COMMITTED_FOR_TRIAL)) {
+                if (result == FullAssessmentResult.INEL) {
+                    meansTestOutcome = MeansTestOutcome.INELIGIBLE;
+                }
+                if (result == FullAssessmentResult.FAIL) {
                     meansTestOutcome = MeansTestOutcome.ELIGIBLE_WITH_CONTRIBUTION;
                 }
-            }
-            if (result == FullAssessmentResult.INEL){
-                    //"Either way" - offence type that could be heard in Magistrates Court
-                    // or Crown Court AND magistrate outcome is COMMITTED_FOR_TRIAL
-                    //All Ineligible
-                    meansTestOutcome = MeansTestOutcome.INELIGIBLE;
-            }
-        }else{
-            // throw exception
-            throw new RuntimeException("Means Test Outcome is not possible. Inputs: result = " + result +
-                                        " caseType = " + caseType + " magCourtOutcome = " + magCourtOutcome);
+                if (result == FullAssessmentResult.PASS) {
+                    meansTestOutcome = MeansTestOutcome.ELIGIBLE_WITH_NO_CONTRIBUTION;
+                }
         }
-        log.info("Outcome of the Full Means Test. Outputs: meansTestOutcome = {}", meansTestOutcome);
+
+        // Appeal to Crown Court
+        if (caseType == CaseType.APPEAL_CC) {
+                if (result == FullAssessmentResult.FAIL) {
+                    meansTestOutcome = MeansTestOutcome.ELIGIBLE_WITH_CONTRIBUTION;
+                }
+                if (result == FullAssessmentResult.PASS) {
+                    meansTestOutcome = MeansTestOutcome.ELIGIBLE_WITH_NO_CONTRIBUTION;
+                }
+        }
+
+        if (meansTestOutcome == null) {
+            throw new RuntimeException("FullMeansTestOutcome: Undefined outcome for these inputs: Full Means Test result = " + result +
+                                       " caseType = " + caseType + " magCourtOutcome = " + magCourtOutcome);
+        }
+        log.info("FullMeansTestOutcome end. Outputs: meansTestOutcome = {}", meansTestOutcome);
         return meansTestOutcome;
     }
 

--- a/src/test/java/uk/gov/justice/laa/crime/cfecrime/utils/FullMeansTestOutcomeCalculatorTest.java
+++ b/src/test/java/uk/gov/justice/laa/crime/cfecrime/utils/FullMeansTestOutcomeCalculatorTest.java
@@ -22,9 +22,9 @@ public class FullMeansTestOutcomeCalculatorTest {
         Exception exception = assertThrows(RuntimeException.class,() -> {
             MeansTestOutcome oc = FullMeansTestOutcomeCalculator.getFullMeansTestOutcome(result, caseType,MagCourtOutcome.COMMITTED);
         });
-        String expectedMsg = "Means Test Outcome is not possible";
+        String expectedMsg = "FullMeansTestOutcome: Undefined outcome";
         String actualMsg = exception.getMessage();
-        assertTrue(actualMsg.contains(expectedMsg));
+        assertTrue(actualMsg.startsWith(expectedMsg));
     }
 
     @Test
@@ -34,9 +34,9 @@ public class FullMeansTestOutcomeCalculatorTest {
         Exception exception = assertThrows(RuntimeException.class,() -> {
             MeansTestOutcome oc = FullMeansTestOutcomeCalculator.getFullMeansTestOutcome(result, caseType, MagCourtOutcome.COMMITTED);
         });
-        String expectedMsg = "Means Test Outcome is not possible";
+        String expectedMsg = "FullMeansTestOutcome: Undefined outcome";
         String actualMsg = exception.getMessage();
-        assertTrue(actualMsg.contains(expectedMsg));
+        assertTrue(actualMsg.startsWith(expectedMsg));
     }
 
     @Test
@@ -46,9 +46,9 @@ public class FullMeansTestOutcomeCalculatorTest {
         Exception exception = assertThrows(RuntimeException.class,() -> {
             MeansTestOutcome oc = FullMeansTestOutcomeCalculator.getFullMeansTestOutcome(result, caseType,null);
         });
-        String expectedMsg = "Means Test Outcome is not possible";
+        String expectedMsg = "FullMeansTestOutcome: Undefined outcome";
         String actualMsg = exception.getMessage();
-        assertTrue(actualMsg.contains(expectedMsg));
+        assertTrue(actualMsg.startsWith(expectedMsg));
     }
 
     @Test
@@ -64,7 +64,7 @@ public class FullMeansTestOutcomeCalculatorTest {
         caseType = CaseType.EITHER_WAY;
         result = FullAssessmentResult.FAIL;
         MeansTestOutcome oc = FullMeansTestOutcomeCalculator.getFullMeansTestOutcome(result, caseType, MagCourtOutcome.COMMITTED_FOR_TRIAL);
-        assertEquals(oc, MeansTestOutcome.INELIGIBLE);
+        assertEquals(oc, MeansTestOutcome.ELIGIBLE_WITH_CONTRIBUTION);
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/laa/crime/cfecrime/utils/FullMeansTestOutcomeCalculatorTest.java
+++ b/src/test/java/uk/gov/justice/laa/crime/cfecrime/utils/FullMeansTestOutcomeCalculatorTest.java
@@ -135,7 +135,7 @@ public class FullMeansTestOutcomeCalculatorTest {
     }
 
     @Test
-    public void INEL_Mags_court() {
+    public void INELResultAndHeardInMagistratesCourt() {
         result = FullAssessmentResult.INEL;
         caseType = CaseType.SUMMARY_ONLY;
         magCourtOutcome = null;
@@ -150,7 +150,7 @@ public class FullMeansTestOutcomeCalculatorTest {
     }
 
     @Test
-    public void INEL_Appeal_to_crown_court() {
+    public void INELResultAndAppealHeardInCrownCourt() {
         result = FullAssessmentResult.INEL;
         caseType = CaseType.APPEAL_CC;
         magCourtOutcome = null;

--- a/src/test/java/uk/gov/justice/laa/crime/cfecrime/utils/FullMeansTestOutcomeCalculatorTest.java
+++ b/src/test/java/uk/gov/justice/laa/crime/cfecrime/utils/FullMeansTestOutcomeCalculatorTest.java
@@ -14,97 +14,153 @@ public class FullMeansTestOutcomeCalculatorTest {
 
     private CaseType caseType;
     private FullAssessmentResult result;
+    private MagCourtOutcome magCourtOutcome;
 
     @Test
-    public void givenAssessmentResult_WhenCaseType_Null_ThenIsNotPossible() {
-        caseType = null;
-        result = FullAssessmentResult.PASS;
-        Exception exception = assertThrows(RuntimeException.class,() -> {
-            MeansTestOutcome oc = FullMeansTestOutcomeCalculator.getFullMeansTestOutcome(result, caseType,MagCourtOutcome.COMMITTED);
-        });
-        String expectedMsg = "FullMeansTestOutcome: Undefined outcome";
-        String actualMsg = exception.getMessage();
-        assertTrue(actualMsg.startsWith(expectedMsg));
-    }
-
-    @Test
-    public void givenAssessmentResult_Null_WhenCaseType_EITHER_WAY_ThenIsNotPossible() {
+    public void INELResultAndHeardInCrownCourt() {
+        result = FullAssessmentResult.INEL;
         caseType = CaseType.EITHER_WAY;
-        result = null;
-        Exception exception = assertThrows(RuntimeException.class,() -> {
-            MeansTestOutcome oc = FullMeansTestOutcomeCalculator.getFullMeansTestOutcome(result, caseType, MagCourtOutcome.COMMITTED);
-        });
-        String expectedMsg = "FullMeansTestOutcome: Undefined outcome";
-        String actualMsg = exception.getMessage();
-        assertTrue(actualMsg.startsWith(expectedMsg));
-    }
+        magCourtOutcome = MagCourtOutcome.COMMITTED_FOR_TRIAL;
 
-    @Test
-    public void givenAssessmentResult_WhenCaseType_EITHER_WAY_MagCourtOutcome_NULL_ThenIsNotPossible() {
-        caseType = CaseType.EITHER_WAY;
-        result = FullAssessmentResult.PASS;
-        Exception exception = assertThrows(RuntimeException.class,() -> {
-            MeansTestOutcome oc = FullMeansTestOutcomeCalculator.getFullMeansTestOutcome(result, caseType,null);
-        });
-        String expectedMsg = "FullMeansTestOutcome: Undefined outcome";
-        String actualMsg = exception.getMessage();
-        assertTrue(actualMsg.startsWith(expectedMsg));
-    }
+        MeansTestOutcome oc = FullMeansTestOutcomeCalculator.getFullMeansTestOutcome(result, caseType, magCourtOutcome);
 
-    @Test
-    public void givenAssessmentResultFail_WhenCaseType_EITHER_WAY_ThenIsInEligible() {
-        caseType = CaseType.EITHER_WAY;
-        result = FullAssessmentResult.FAIL;
-        MeansTestOutcome oc = FullMeansTestOutcomeCalculator.getFullMeansTestOutcome(result, caseType, MagCourtOutcome.COMMITTED);
         assertEquals(oc, MeansTestOutcome.INELIGIBLE);
     }
 
     @Test
-    public void givenAssessmentResultFail_WhenCaseType_EITHER_WAY_COMMITTED_FOR_TRIAL_ThenIsInEligible() {
-        caseType = CaseType.EITHER_WAY;
+    public void FAILResultAndHeardInMagistratesCourt() {
         result = FullAssessmentResult.FAIL;
-        MeansTestOutcome oc = FullMeansTestOutcomeCalculator.getFullMeansTestOutcome(result, caseType, MagCourtOutcome.COMMITTED_FOR_TRIAL);
+        caseType = CaseType.COMMITAL;
+        magCourtOutcome = null;
+
+        MeansTestOutcome oc = FullMeansTestOutcomeCalculator.getFullMeansTestOutcome(result, caseType, magCourtOutcome);
+
+        assertEquals(oc, MeansTestOutcome.INELIGIBLE);
+    }
+
+    @Test
+    public void FAILResultAndHeardInCrownCourt() {
+        result = FullAssessmentResult.FAIL;
+        caseType = CaseType.INDICTABLE;
+        magCourtOutcome = null;
+
+        MeansTestOutcome oc = FullMeansTestOutcomeCalculator.getFullMeansTestOutcome(result, caseType, magCourtOutcome);
+
         assertEquals(oc, MeansTestOutcome.ELIGIBLE_WITH_CONTRIBUTION);
     }
 
     @Test
-    public void givenAssessmentResultFail_WhenCaseType_SUMMARY_ONLY_COMMITTED_FOR_TRIAL_ThenIsInEligible() {
+    public void FAILResultAndAppealHeardInCrownCourt() {
+        result = FullAssessmentResult.FAIL;
+        caseType = CaseType.APPEAL_CC;
+        magCourtOutcome = null;
+
+        MeansTestOutcome oc = FullMeansTestOutcomeCalculator.getFullMeansTestOutcome(result, caseType, magCourtOutcome);
+
+        assertEquals(oc, MeansTestOutcome.ELIGIBLE_WITH_CONTRIBUTION);
+    }
+
+    @Test
+    public void PASSResultAndHeardInMagistratesCourt() {
+        result = FullAssessmentResult.PASS;
         caseType = CaseType.SUMMARY_ONLY;
-        result = FullAssessmentResult.FAIL;
-        MeansTestOutcome oc = FullMeansTestOutcomeCalculator.getFullMeansTestOutcome(result, caseType, MagCourtOutcome.COMMITTED_FOR_TRIAL);
-        assertEquals(oc, MeansTestOutcome.INELIGIBLE);
-    }
+        magCourtOutcome = null;
 
-    @Test
-    public void givenAssessmentResultFail_WhenCaseType_EITHER_WAY_COMMITTED_ThenIsInEligible() {
-        caseType = CaseType.EITHER_WAY;
-        result = FullAssessmentResult.FAIL;
-        MeansTestOutcome oc = FullMeansTestOutcomeCalculator.getFullMeansTestOutcome(result, caseType, MagCourtOutcome.COMMITTED);
-        assertEquals(oc, MeansTestOutcome.INELIGIBLE);
-    }
+        MeansTestOutcome oc = FullMeansTestOutcomeCalculator.getFullMeansTestOutcome(result, caseType, magCourtOutcome);
 
-    @Test
-    public void givenAssessmentResultFail_WhenCaseType_CC_ALREADY_ThenIsEligibleWithContribution() {
-        caseType = CaseType.CC_ALREADY;
-        result = FullAssessmentResult.FAIL;
-        MeansTestOutcome oc = FullMeansTestOutcomeCalculator.getFullMeansTestOutcome(result, caseType,MagCourtOutcome.COMMITTED);
-        assertEquals(oc, MeansTestOutcome.ELIGIBLE_WITH_CONTRIBUTION);
-    }
-
-    @Test
-    public void givenAssessmentResultPass_WhenCaseType_EITHER_WAY_ThenIsEligibleWithNoContribution() {
-        caseType = CaseType.EITHER_WAY;
-        result = FullAssessmentResult.PASS;
-        MeansTestOutcome oc = FullMeansTestOutcomeCalculator.getFullMeansTestOutcome(result, caseType,MagCourtOutcome.COMMITTED);
         assertEquals(oc, MeansTestOutcome.ELIGIBLE_WITH_NO_CONTRIBUTION);
     }
 
     @Test
-    public void givenAssessmentResultINEL_WhenCaseType_EITHER_WAY_ThenIsInEligible() {
+    public void PASSResultAndHeardInMagistratesCourtEitherWay() {
+        result = FullAssessmentResult.PASS;
         caseType = CaseType.EITHER_WAY;
-        result = FullAssessmentResult.INEL;
-        MeansTestOutcome oc = FullMeansTestOutcomeCalculator.getFullMeansTestOutcome(result, caseType,MagCourtOutcome.COMMITTED_FOR_TRIAL);
-        assertEquals(oc, MeansTestOutcome.INELIGIBLE);
+        magCourtOutcome = MagCourtOutcome.RESOLVED_IN_MAGS;
+
+        MeansTestOutcome oc = FullMeansTestOutcomeCalculator.getFullMeansTestOutcome(result, caseType, magCourtOutcome);
+
+        assertEquals(oc, MeansTestOutcome.ELIGIBLE_WITH_NO_CONTRIBUTION);
     }
 
+    @Test
+    public void PASSResultAndHeardInCrownCourt() {
+        result = FullAssessmentResult.PASS;
+        caseType = CaseType.CC_ALREADY;
+        magCourtOutcome = null;
+
+        MeansTestOutcome oc = FullMeansTestOutcomeCalculator.getFullMeansTestOutcome(result, caseType, magCourtOutcome);
+
+        assertEquals(oc, MeansTestOutcome.ELIGIBLE_WITH_NO_CONTRIBUTION);
+    }
+
+    @Test
+    public void PASSResultAndAppealHeardInCrownCourt() {
+        result = FullAssessmentResult.PASS;
+        caseType = CaseType.APPEAL_CC;
+        magCourtOutcome = null;
+
+        MeansTestOutcome oc = FullMeansTestOutcomeCalculator.getFullMeansTestOutcome(result, caseType, magCourtOutcome);
+
+        assertEquals(oc, MeansTestOutcome.ELIGIBLE_WITH_NO_CONTRIBUTION);
+    }
+
+    // unhappy paths
+
+    @Test
+    public void nullCaseType() {
+        result = FullAssessmentResult.PASS;
+        caseType = null;
+        magCourtOutcome = null;
+
+        Exception exception = assertThrows(RuntimeException.class, () -> {
+            FullMeansTestOutcomeCalculator.getFullMeansTestOutcome(result, caseType, magCourtOutcome);
+        });
+
+        String expectedMsg = "FullMeansTestOutcome: Undefined outcome";
+        assertTrue(exception.getMessage().startsWith(expectedMsg));
+    }
+
+    @Test
+    public void nullResult() {
+        result = null;
+        caseType = CaseType.EITHER_WAY;
+        magCourtOutcome = MagCourtOutcome.RESOLVED_IN_MAGS;
+
+        Exception exception = assertThrows(RuntimeException.class, () -> {
+            FullMeansTestOutcomeCalculator.getFullMeansTestOutcome(result, caseType, magCourtOutcome);
+        });
+
+        String expectedMsg = "FullMeansTestOutcome: Undefined outcome";
+        assertTrue(exception.getMessage().startsWith(expectedMsg));
+    }
+
+    @Test
+    public void INEL_Mags_court() {
+        result = FullAssessmentResult.INEL;
+        caseType = CaseType.SUMMARY_ONLY;
+        magCourtOutcome = null;
+
+        // INEL should only happen for crown court cases, not this mags court hearing
+        Exception exception = assertThrows(RuntimeException.class, () -> {
+            FullMeansTestOutcomeCalculator.getFullMeansTestOutcome(result, caseType, magCourtOutcome);
+        });
+
+        String expectedMsg = "FullMeansTestOutcome: Undefined outcome";
+        assertTrue(exception.getMessage().startsWith(expectedMsg));
+    }
+
+    @Test
+    public void INEL_Appeal_to_crown_court() {
+        result = FullAssessmentResult.INEL;
+        caseType = CaseType.APPEAL_CC;
+        magCourtOutcome = null;
+
+        // INEL should only happen for non-appeal crown court cases, not this appeal to the crown court hearing
+        Exception exception = assertThrows(RuntimeException.class, () -> {
+            FullMeansTestOutcomeCalculator.getFullMeansTestOutcome(result, caseType, magCourtOutcome);
+        });
+
+        String expectedMsg = "FullMeansTestOutcome: Undefined outcome";
+        assertTrue(exception.getMessage().startsWith(expectedMsg));
+    }
 }


### PR DESCRIPTION
This version is more 'defensive' - it only returns outputs for the known combinations of inputs. All others will raise an exception, for example if a new value for `result` or `caseType` is supplied, or for the 'not possible' combinations too.