### PR TITLE
Fix ports for deployment

### DIFF
--- a/deploy/helm/templates/deployment_web.yaml
+++ b/deploy/helm/templates/deployment_web.yaml
@@ -26,17 +26,17 @@ spec:
 {{ include "app.envs" . | nindent 10 }}
           ports:
             - name: http
-              containerPort: 8096
+              containerPort: 8080
               protocol: TCP
           livenessProbe:
             httpGet:
               path: /actuator/health
-              port: http
+              port: 8096
             initialDelaySeconds: 45
           readinessProbe:
             httpGet:
               path: /actuator/health
-              port: http
+              port: 8096
             initialDelaySeconds: 45
           resources:
 {{ toYaml .Values.resources | indent 12 }}


### PR DESCRIPTION
This was figured out by editing the ports in the k8s deployment until the pods started ok and responded to API requests.

Here's the edited deployment (relevant parts):
```
$ kubectl -n cfe-crime-dev get deployment -oyaml 
...
      spec:
        containers:
          ports:
          - containerPort: 8080
            name: http
            protocol: TCP
         livenessProbe:
            failureThreshold: 3
            httpGet:
              path: /actuator/health
              port: 8096
              scheme: HTTP
          readinessProbe:
            failureThreshold: 3
            httpGet:
              path: /actuator/health
              port: 8096
              scheme: HTTP
```
and here's how we showed it worked:
```
$ curl https://cfe-crime-dev.cloud-platform.service.justice.gov.uk/v1/assessment -H 'Content-Type: application/json' -X POST -d '{"assessment":{"assessment_date": "Thu Aug 03 16:35:31 BST 2023"},"section_under_18":{"client_under_18":true}}'
{"result":{"outcome":"eligible"}}
```
