### PR TITLE
Lep 311 cma spring3 auth

### DIFF
--- a/src/main/java/uk/gov/justice/laa/crime/cfecrime/config/SecurityConfig.java
+++ b/src/main/java/uk/gov/justice/laa/crime/cfecrime/config/SecurityConfig.java
@@ -1,20 +1,21 @@
 package uk.gov.justice.laa.crime.cfecrime.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
-@EnableGlobalMethodSecurity(securedEnabled = true)
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+public class SecurityConfig {
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        http.authorizeRequests()
-                .anyRequest().permitAll();
-        http.csrf().disable();
+//    including oauth2 in the project attempts to secure *our* endpoints with oauth2, when what we want to do
+    // is just *talk to* an oauth2-secured endpoint (and not be secured ourselves) so we have to disable it
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf((csrf) -> csrf.disable());
+        http.authorizeHttpRequests((authz) -> authz.anyRequest().permitAll());
+        return http.build();
     }
 }

--- a/src/main/java/uk/gov/justice/laa/crime/cfecrime/enums/Outcome.java
+++ b/src/main/java/uk/gov/justice/laa/crime/cfecrime/enums/Outcome.java
@@ -11,7 +11,7 @@ public enum Outcome {
     ELIGIBLE_WITH_NO_CONTRIBUTION("Eligible with no income contribution"),
     INELIGIBLE("Ineligible");
 
-    private String outcome;
+    private final String outcome;
 
     private Outcome(String outcome){
         this.outcome = outcome;

--- a/src/test/java/uk/gov/justice/laa/crime/cfecrime/CfeCrimeControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/crime/cfecrime/CfeCrimeControllerTest.java
@@ -1,20 +1,23 @@
 package uk.gov.justice.laa.crime.cfecrime;
 
-import org.json.JSONObject;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.web.FilterChainProxy;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 import uk.gov.justice.laa.crime.cfecrime.api.CfeCrimeRequest;
 import uk.gov.justice.laa.crime.cfecrime.api.CfeCrimeResponse;
 import uk.gov.justice.laa.crime.cfecrime.cma.stubs.LocalCmaService;
 import uk.gov.justice.laa.crime.cfecrime.cma.stubs.utils.CmaResponseUtil;
-import uk.gov.justice.laa.crime.cfecrime.controllers.CfeCrimeController;
 import uk.gov.justice.laa.crime.cfecrime.interfaces.ICmaService;
 import uk.gov.justice.laa.crime.cfecrime.utils.RequestTestUtil;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.CaseType;
@@ -26,23 +29,46 @@ import java.util.Map;
 import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.DEFINED_PORT;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(CfeCrimeController.class)
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(
+        classes = {
+                CfeCrimeApplication.class
+        }, webEnvironment = DEFINED_PORT)
 class CfeCrimeControllerTest {
-    @Autowired
     private MockMvc mvc;
+
     private static Logger log = Logger.getLogger(String.valueOf(CfeCrimeControllerTest.class));
 
+    private static final String MEANS_ASSESSMENT_ENDPOINT_URL = "/v1/assessment";
+
     private ICmaService cmaService;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private FilterChainProxy springSecurityFilterChain;
 
     final String BAD_REQUEST_ERROR = "Bad CFE Crime Request";
     @BeforeEach
     public void init(){
         cmaService = new LocalCmaService(InitAssessmentResult.FULL, FullAssessmentResult.INEL, false);
     }
+
+    @BeforeEach
+    void setup() {
+        this.mvc = MockMvcBuilders.webAppContextSetup(this.webApplicationContext)
+                .addFilter(springSecurityFilterChain).build();
+    }
+
     @Test
     void validJsonProducesSuccessResult() throws Exception {
 
@@ -50,10 +76,10 @@ class CfeCrimeControllerTest {
         RequestTestUtil.setAssessment(request);
         RequestTestUtil.setSectionUnder18(request,true);
 
-        var content = RequestTestUtil.getRequestAsJson(request);
+        var content = objectMapper.writeValueAsString(request);
 
         MockHttpServletResponse response = mvc.perform(
-                        post("/v1/assessment")
+                        post(MEANS_ASSESSMENT_ENDPOINT_URL)
                                 .accept(MediaType.APPLICATION_JSON)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(content))
@@ -70,7 +96,7 @@ class CfeCrimeControllerTest {
         CfeCrimeRequest request = new CfeCrimeRequest();
         RequestTestUtil.setAssessment(request);
 
-        var content = RequestTestUtil.getRequestAsJson(request);
+        var content = objectMapper.writeValueAsString(request);
 
         MockHttpServletResponse response = mvc.perform(
                         post("/v1/assessment")
@@ -82,8 +108,7 @@ class CfeCrimeControllerTest {
 
         assertEquals(HttpStatus.OK.value(), response.getStatus());
         CfeCrimeResponse responseExpected = new CfeCrimeResponse();
-        ObjectMapper objMapper = new ObjectMapper();
-        assertEquals(objMapper.writeValueAsString(responseExpected), response.getContentAsString());
+        assertEquals(objectMapper.writeValueAsString(responseExpected), response.getContentAsString());
         assertEquals("{}", response.getContentAsString());
 
     }
@@ -92,7 +117,7 @@ class CfeCrimeControllerTest {
     void invalidJsonProducesErrorResult() throws Exception {
         var assessment = Map.of("assessment",
                 Map.of("submission_date", "2023-05-02"));
-        var content = new JSONObject(assessment).toString();
+        var content = objectMapper.writeValueAsString(assessment);
         MockHttpServletResponse response = mvc.perform(
                         post("/v1/assessment")
                                 .accept(MediaType.APPLICATION_JSON)
@@ -114,7 +139,7 @@ class CfeCrimeControllerTest {
         RequestTestUtil.setSectionInitMeansTest(cfeCrimeRequest, CaseType.APPEAL_CC, MagCourtOutcome.RESOLVED_IN_MAGS);
         RequestTestUtil.setSectionFullMeansTest(cfeCrimeRequest);
         CmaResponseUtil.setCmaResponse((LocalCmaService) cmaService, false, FullAssessmentResult.INEL, InitAssessmentResult.FULL);
-        String jsonStringContent = RequestTestUtil.getRequestAsJson(cfeCrimeRequest);
+        String jsonStringContent = objectMapper.writeValueAsString(cfeCrimeRequest);
         log.info("CfeCrimeRequest = "+ jsonStringContent);
         MockHttpServletResponse response = mvc.perform(
                         post("/v1/assessment")
@@ -139,7 +164,7 @@ class CfeCrimeControllerTest {
         RequestTestUtil.setSectionInitMeansTestError(cfeCrimeRequest, CaseType.SUMMARY_ONLY, null);
         RequestTestUtil.setSectionFullMeansTest(cfeCrimeRequest);
         CmaResponseUtil.setCmaResponse((LocalCmaService) cmaService, false, FullAssessmentResult.INEL, InitAssessmentResult.FULL);
-        String jsonStringContent = RequestTestUtil.getRequestAsJson(cfeCrimeRequest);
+        String jsonStringContent = objectMapper.writeValueAsString(cfeCrimeRequest);
         log.info("CfeCrimeRequest = "+ jsonStringContent);
         MockHttpServletResponse response = mvc.perform(
                         post("/v1/assessment")


### PR DESCRIPTION
LEP-311 Part 2 - use Spring Boot 3 compatible authentication.

Converted all controller tests to move up a level - they all failed without this change (but don't know why)