### PR TITLE
LEP-311 call cma with auth

### DIFF
--- a/deploy/helm/templates/_envs.tpl
+++ b/deploy/helm/templates/_envs.tpl
@@ -4,4 +4,16 @@ Environment variables for web and worker containers
 */}}
 {{- define "app.envs" }}
 env:
+  - name: CMA_API_OAUTH_URL
+    value: {{ .Values.cmaApi.oauthUrl }}
+  - name: CMA_API_OAUTH_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: kube-secrets
+        key: cma_api_oauth_client_id
+  - name: CMA_API_OAUTH_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: kube-secrets
+        key: cma_api_oauth_client_secret
 {{- end }}

--- a/deploy/helm/values/dev.yaml
+++ b/deploy/helm/values/dev.yaml
@@ -26,5 +26,8 @@ ingress:
 deploy:
   host: cfe-crime-dev.cloud-platform.service.justice.gov.uk
 
+cmaApi:
+  oauthUrl: https://laa-crime-auth-cma.auth.eu-west-2.amazoncognito.com/oauth2/token
+
 sentry:
   enabled: enabled

--- a/src/main/java/uk/gov/justice/laa/crime/cfecrime/cma/stubs/LocalCmaService.java
+++ b/src/main/java/uk/gov/justice/laa/crime/cfecrime/cma/stubs/LocalCmaService.java
@@ -12,9 +12,9 @@ import java.math.BigDecimal;
 
 public class LocalCmaService implements ICmaService {
 
-    private  InitAssessmentResult initAssessmentResult = null;
-    private  FullAssessmentResult fullAssessmentResult = null;
-    private  boolean fullAssessmentPossible = false;
+    private  InitAssessmentResult initAssessmentResult;
+    private  FullAssessmentResult fullAssessmentResult;
+    private  boolean fullAssessmentPossible;
 
     public LocalCmaService(InitAssessmentResult initAssessmentResult,FullAssessmentResult fullAssessmentResult,boolean fullAssessmentPossible){
          this.initAssessmentResult = initAssessmentResult;

--- a/src/main/java/uk/gov/justice/laa/crime/cfecrime/config/OAuthConfiguration.java
+++ b/src/main/java/uk/gov/justice/laa/crime/cfecrime/config/OAuthConfiguration.java
@@ -1,0 +1,29 @@
+package uk.gov.justice.laa.crime.cfecrime.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class OAuthConfiguration {
+
+    private static final String DEV_HOST_NAME = "laa-crime-means-assessment-dev.apps.live.cloud-platform.service.justice.gov.uk";
+    private static final String API_BASE_PATH = "/api/internal";
+    @Bean
+    WebClient webClient(ClientRegistrationRepository clientRegistrations,
+                        OAuth2AuthorizedClientRepository authorizedClients) {
+        var oauth =
+                new ServletOAuth2AuthorizedClientExchangeFilterFunction(clientRegistrations, authorizedClients);
+        // explicitly opt into using the oauth2Login to provide an access token implicitly
+        oauth.setDefaultOAuth2AuthorizedClient(true);
+        oauth.setDefaultClientRegistrationId("cma-api");
+
+        return WebClient.builder()
+                .filter(oauth)
+                .baseUrl("https://" + DEV_HOST_NAME + API_BASE_PATH)
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/justice/laa/crime/cfecrime/controllers/CfeCrimeController.java
+++ b/src/main/java/uk/gov/justice/laa/crime/cfecrime/controllers/CfeCrimeController.java
@@ -5,26 +5,28 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.validation.BindingResult;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 import uk.gov.justice.laa.crime.cfecrime.api.CfeCrimeRequest;
 import uk.gov.justice.laa.crime.cfecrime.api.CfeCrimeResponse;
-import uk.gov.justice.laa.crime.cfecrime.cma.stubs.LocalCmaService;
+import uk.gov.justice.laa.crime.cfecrime.utils.RemoteCmaService;
 import uk.gov.justice.laa.crime.cfecrime.utils.RequestHandler;
-import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.InitAssessmentResult;
-
-import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/v1/assessment")
+@RequiredArgsConstructor
 public class CfeCrimeController {
+
+    private final RemoteCmaService cmaService;
 
     @Operation(description = "CFE Crime")
     @ApiResponse(responseCode = "200",
@@ -40,15 +42,6 @@ public class CfeCrimeController {
             )
     ) @RequestBody @Valid CfeCrimeRequest request, BindingResult bindingResult)  {
         if (!bindingResult.hasErrors()) {
-            CfeCrimeResponse response = null;
-            LocalCmaService cmaService;
-            if (request.getSectionInitialMeansTest() == null) {
-                //this is to get the 'Undefined outcome for these inputs' test to work
-                //CfeCrimeControllerTest at line 111 method: exceptionJsonProducesErrorResult
-                cmaService = new LocalCmaService(null, null, false);
-            }else{
-                cmaService = new LocalCmaService(InitAssessmentResult.FULL, null, false);
-            }
             RequestHandler requestHandler = new RequestHandler(cmaService);
             return ResponseEntity.ok(requestHandler.handleRequest(request));
         }else{

--- a/src/main/java/uk/gov/justice/laa/crime/cfecrime/controllers/CfeCrimeError.java
+++ b/src/main/java/uk/gov/justice/laa/crime/cfecrime/controllers/CfeCrimeError.java
@@ -4,6 +4,7 @@ package uk.gov.justice.laa.crime.cfecrime.controllers;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.ObjectError;
+
 import java.time.LocalDateTime;
 import java.util.List;
 

--- a/src/main/java/uk/gov/justice/laa/crime/cfecrime/controllers/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/justice/laa/crime/cfecrime/controllers/GlobalExceptionHandler.java
@@ -8,7 +8,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,19 +17,19 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     final String BAD_REQUEST_ERROR = "Bad CFE Crime Request";
     @ExceptionHandler({Exception.class})
     public ResponseEntity<Object> handleAll(Exception ex, WebRequest request){
-       List<ObjectError> details = new ArrayList<>();
+        List<ObjectError> details = new ArrayList<>();
         ObjectError objectError = null;
-       if (ex.getCause() != null && ex.getCause().getLocalizedMessage() != null) {
-           objectError = new ObjectError(BAD_REQUEST_ERROR , ex.getCause().getLocalizedMessage());
-       }else{
-           objectError = new ObjectError(BAD_REQUEST_ERROR , ex.getLocalizedMessage());
-       }
+        if (ex.getCause() != null && ex.getCause().getLocalizedMessage() != null) {
+            objectError = new ObjectError(BAD_REQUEST_ERROR , ex.getCause().getLocalizedMessage());
+        }else{
+            objectError = new ObjectError(BAD_REQUEST_ERROR , ex.getLocalizedMessage());
+        }
 
-       details.add(objectError);
-       CfeCrimeError cfeCrimeError = new CfeCrimeError(HttpStatus.BAD_REQUEST,BAD_REQUEST_ERROR,details);
+        details.add(objectError);
+        CfeCrimeError cfeCrimeError = new CfeCrimeError(HttpStatus.BAD_REQUEST,BAD_REQUEST_ERROR,details);
 
-       ResponseEntityBuilder builder = new ResponseEntityBuilder();
-       return builder.build(cfeCrimeError);
+        ResponseEntityBuilder builder = new ResponseEntityBuilder();
+        return builder.build(cfeCrimeError);
 
     }
 }

--- a/src/main/java/uk/gov/justice/laa/crime/cfecrime/utils/RemoteCmaService.java
+++ b/src/main/java/uk/gov/justice/laa/crime/cfecrime/utils/RemoteCmaService.java
@@ -1,0 +1,34 @@
+package uk.gov.justice.laa.crime.cfecrime.utils;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import uk.gov.justice.laa.crime.cfecrime.api.stateless.StatelessApiRequest;
+import uk.gov.justice.laa.crime.cfecrime.api.stateless.StatelessApiResponse;
+import uk.gov.justice.laa.crime.cfecrime.interfaces.ICmaService;
+
+@Service
+@RequiredArgsConstructor
+public class RemoteCmaService implements ICmaService {
+
+    private static final String CMA2_ENDPOINT = "/v2/assessment/means";
+
+    @Autowired
+    private WebClient webClient;
+
+    @Override
+    public StatelessApiResponse callCma(StatelessApiRequest request) {
+        Mono<StatelessApiRequest> api_request = Mono.just(request);
+        var response = webClient.post()
+                .uri(CMA2_ENDPOINT)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(api_request, StatelessApiRequest.class)
+                .retrieve()
+                .bodyToMono(StatelessApiResponse.class)
+                .block();
+        return response;
+    }
+}

--- a/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/stateless/StatelessFullResult.java
+++ b/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/stateless/StatelessFullResult.java
@@ -1,21 +1,23 @@
 package uk.gov.justice.laa.crime.meansassessment.service.stateless;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.FullAssessmentResult;
 
 import java.math.BigDecimal;
 
-@RequiredArgsConstructor
+@NoArgsConstructor
+@AllArgsConstructor
 @Getter
 public class StatelessFullResult {
-    private final FullAssessmentResult result;
-    private final BigDecimal disposableIncome;
-    private final BigDecimal adjustedIncomeValue;
-    private final BigDecimal totalAggregatedIncome;
-    private final BigDecimal adjustedLivingAllowance;
-    private final BigDecimal totalAnnualAggregatedExpenditure;
-    private final BigDecimal eligibilityThreshold;
+    private FullAssessmentResult result;
+    private  BigDecimal disposableIncome;
+    private  BigDecimal adjustedIncomeValue;
+    private BigDecimal totalAggregatedIncome;
+    private  BigDecimal adjustedLivingAllowance;
+    private  BigDecimal totalAnnualAggregatedExpenditure;
+    private  BigDecimal eligibilityThreshold;
 
     public String getResultReason() {
         return result.getReason();

--- a/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/stateless/StatelessInitialResult.java
+++ b/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/stateless/StatelessInitialResult.java
@@ -1,18 +1,20 @@
 package uk.gov.justice.laa.crime.meansassessment.service.stateless;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.InitAssessmentResult;
 
 import java.math.BigDecimal;
 
-@RequiredArgsConstructor
+@NoArgsConstructor
+@AllArgsConstructor
 @Getter
 public class StatelessInitialResult {
-    private final InitAssessmentResult result;
-    private final BigDecimal lowerThreshold;
-    private final BigDecimal upperThreshold;
-    private final boolean fullAssessmentPossible;
+    private InitAssessmentResult result;
+    private BigDecimal lowerThreshold;
+    private BigDecimal upperThreshold;
+    private boolean fullAssessmentPossible;
 
     public String getResultReason() {
         return result.getReason();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,7 +5,7 @@ logging:
   level:
     root: INFO
     org.springframework.web: INFO
-    org.springframework.security: DEBUG
+    org.springframework.security: INFO
 
 management:
   server:
@@ -15,4 +15,19 @@ management:
       exposure:
         include: health
 
-version: 0.0.2
+spring:
+  security:
+    oauth2:
+      client:
+        provider:
+          cma-api:
+            token-uri: ${CMA_API_OAUTH_URL}
+#            token-uri: https://laa-crime-auth-cma.auth.eu-west-2.amazoncognito.com/oauth2/token
+            user-info-authentication-method: header
+        registration:
+          cma-api:
+            client-id: ${CMA_API_OAUTH_CLIENT_ID}
+            client-secret: ${CMA_API_OAUTH_CLIENT_SECRET}
+            authorization-grant-type: client_credentials
+
+version: 0.0.3

--- a/src/test/java/uk/gov/justice/laa/crime/cfecrime/CfeCrimeControllerMockingTest.java
+++ b/src/test/java/uk/gov/justice/laa/crime/cfecrime/CfeCrimeControllerMockingTest.java
@@ -1,0 +1,76 @@
+package uk.gov.justice.laa.crime.cfecrime;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.justice.laa.crime.cfecrime.api.CfeCrimeRequest;
+import uk.gov.justice.laa.crime.cfecrime.api.stateless.StatelessApiRequest;
+import uk.gov.justice.laa.crime.cfecrime.cma.stubs.LocalCmaService;
+import uk.gov.justice.laa.crime.cfecrime.controllers.CfeCrimeController;
+import uk.gov.justice.laa.crime.cfecrime.utils.RemoteCmaService;
+import uk.gov.justice.laa.crime.cfecrime.utils.RequestTestUtil;
+import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.CaseType;
+import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.FullAssessmentResult;
+import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.InitAssessmentResult;
+import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.MagCourtOutcome;
+import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.stateless.StatelessRequestType;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(CfeCrimeController.class)
+class CfeCrimeControllerMockingTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    private static final String MEANS_ASSESSMENT_ENDPOINT_URL = "/v1/assessment";
+
+    @MockBean
+    private RemoteCmaService cmaService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void exceptionJsonProducesErrorResult() throws Exception {
+        CfeCrimeRequest cfeCrimeRequest = new CfeCrimeRequest();
+        RequestTestUtil.setAssessment(cfeCrimeRequest, StatelessRequestType.BOTH);
+        RequestTestUtil.setSectionUnder18(cfeCrimeRequest,false);
+        RequestTestUtil.setSectionPassportBenefit(cfeCrimeRequest, false);
+        RequestTestUtil.setSectionInitMeansTest(cfeCrimeRequest, CaseType.APPEAL_CC, MagCourtOutcome.RESOLVED_IN_MAGS);
+        RequestTestUtil.setSectionFullMeansTest(cfeCrimeRequest);
+
+        var invalidResponse = new LocalCmaService(InitAssessmentResult.FULL, FullAssessmentResult.INEL, false);
+        when(cmaService.callCma(any(StatelessApiRequest.class))).thenReturn(invalidResponse.callCma(null));
+
+        String jsonStringContent = objectMapper.writeValueAsString(cfeCrimeRequest);
+        MockHttpServletResponse response = mvc.perform(
+                        post(MEANS_ASSESSMENT_ENDPOINT_URL)
+                                .accept(MediaType.APPLICATION_JSON)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(jsonStringContent))
+                .andExpect(status().isBadRequest())
+                .andDo(print())
+                .andReturn()
+                .getResponse();
+
+        assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
+        assertEquals(response.getContentAsString().contains("Undefined outcome for these inputs"),true, "Response Body contains 'Undefined outcome for these inputs'");
+    }
+}

--- a/src/test/java/uk/gov/justice/laa/crime/cfecrime/steps/InitialMeansTestStepDefs.java
+++ b/src/test/java/uk/gov/justice/laa/crime/cfecrime/steps/InitialMeansTestStepDefs.java
@@ -40,7 +40,7 @@ public class InitialMeansTestStepDefs {
     @BeforeStep
     public void init() {
         cfeCrimeRequest = new CfeCrimeRequest();
-        RequestTestUtil.setAssessment(cfeCrimeRequest, StatelessRequestType.BOTH);
+        RequestTestUtil.setAssessment(cfeCrimeRequest, StatelessRequestType.INITIAL);
         cmaService = new LocalCmaService(InitAssessmentResult.PASS, FullAssessmentResult.INEL, false);
         requestHandler = new RequestHandler(cmaService);
 
@@ -88,6 +88,8 @@ public class InitialMeansTestStepDefs {
 
             cfeCrimeRequest = new CfeCrimeRequest();
             RequestTestUtil.setAssessment(cfeCrimeRequest, StatelessRequestType.BOTH);
+            RequestTestUtil.setSectionUnder18(cfeCrimeRequest, false);
+            RequestTestUtil.setSectionPassportBenefit(cfeCrimeRequest, false);
             RequestTestUtil.setSectionInitMeansTest(cfeCrimeRequest, inputData.caseType, inputData.magCourtOutcome);
             RequestTestUtil.setSectionFullMeansTest(cfeCrimeRequest);
             try {


### PR DESCRIPTION
Call CMA URL from RequestHandler.

 Doesn't use wiremock - the documentation is not as easy to navigate as first appeared, and attempts to setup a proxy environment failed. 